### PR TITLE
add font-family definition to the language selector

### DIFF
--- a/static/custom.css
+++ b/static/custom.css
@@ -16,6 +16,7 @@ ul {
 .languages {
   padding: 20px 20px 0;
   justify-content: flex-end;
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, freesans, sans-serif;
 }
 
 .languages > li {


### PR DESCRIPTION
Proposed font-family is similar to github-markdown.css (now it is not defined and renders as a default serif one)
