### PR TITLE
Add talk names - to be replaced with videos in the future

### DIFF
--- a/en/index.md
+++ b/en/index.md
@@ -5,7 +5,7 @@ layout: default
   - # ![KyivJS](/static/kyiv-js-rectangle-no-alpha.png)
   - [Twitter](https://twitter.com/kyivjs)
   - [Gitter](https://gitter.im/dev-ua/frontend-ua/kyivjs)
-  - [Registration](https://docs.google.com/forms/d/1STin1SD4o1lx9DNCUTqFrwjc5JxzOPROyDb8EJUz2CI/viewform)
+  - [Registration <br/> Coming Soon]()
 
 ## Upcoming Event: TBA
 <!--
@@ -17,10 +17,21 @@ Meanwhile, if you want to share something with the community, we encourage you t
 
 ### [January 30th, 2016](http://dou.ua/calendar/9623/), [Videos](javascript:alert\('Coming soon'\);)
 
-  - ![Avatar](https://media.licdn.com/mpr/mpr/shrinknp_400_400/p/7/005/0a8/057/07bb452.jpg) [Denis Zaichenko](https://www.linkedin.com/in/dzaichenko)
-  - ![Avatar](https://media.licdn.com/mpr/mpr/shrinknp_400_400/AAEAAQAAAAAAAAZDAAAAJGM0ZTIzMzRkLTUzMjEtNDU3Yi1hNTM4LTI1YzZkNWIxZTNkZA.jpg) [Pavel Ponomarenko](https://github.com/theshock)
-  - ![Avatar](https://media.licdn.com/media/AAEAAQAAAAAAAAK6AAAAJDVlZTAwOTZlLTdkZDEtNDUzNy1hYjk5LTMzNTk5MjNkZDA0OQ.jpg) [Aleksey Shvayka](https://www.linkedin.com/in/ashvayka)
-  - ![Avatar](https://media.licdn.com/mpr/mpr/shrinknp_400_400/p/7/005/0ac/25b/06c95fa.jpg) [Evgeniy Safronov](https://github.com/javacodegeek)
+  - ![Avatar](https://media.licdn.com/mpr/mpr/shrinknp_400_400/p/7/005/0a8/057/07bb452.jpg)
+    > [**Denis Zaichenko**](https://www.linkedin.com/in/dzaichenko)  
+    [Best practices - Angular JS]()
+
+  - ![Avatar](https://media.licdn.com/mpr/mpr/shrinknp_400_400/AAEAAQAAAAAAAAZDAAAAJGM0ZTIzMzRkLTUzMjEtNDU3Yi1hNTM4LTI1YzZkNWIxZTNkZA.jpg)
+    > [**Pavlo Ponomarenko**](https://github.com/theshock)  
+    [Plugins for JavaScript games](http://slides.com/theshock/javascript-plugins/)
+
+  - ![Avatar](https://media.licdn.com/media/AAEAAQAAAAAAAAK6AAAAJDVlZTAwOTZlLTdkZDEtNDUzNy1hYjk5LTMzNTk5MjNkZDA0OQ.jpg)
+    > [**Aleksey Shvayka**](https://www.linkedin.com/in/ashvayka)  
+    [ES6 Classes]()
+
+  - ![Avatar](https://media.licdn.com/mpr/mpr/shrinknp_400_400/p/7/005/0ac/25b/06c95fa.jpg)
+    > [**Evgeniy Safronov**](https://github.com/javacodegeek)  
+    [Scala.JS](https://www.dropbox.com/s/dnkkgwjflul54ny/Scala-JS%20%28KyivJS%2030-01%29.pdf?dl=0)
 
 
 ### [December 5th, 2015](http://dou.ua/calendar/9101/), [Videos](javascript:alert\('Coming soon'\);)
@@ -52,7 +63,7 @@ Meanwhile, if you want to share something with the community, we encourage you t
 
 ### [October 19th, 2013](http://dou.ua/calendar/3915/)
 
-  - ![Avatar](http://m.c.lnkd.licdn.com/media/p/6/000/23e/325/13e4d75.jpg) [Vyatcheslav Potravnyy](http://ua.linkedin.com/pub/vyatcheslav-potravnyy/4a/414/50b/)
+  - ![Avatar](https://media.licdn.com/mpr/mpr/shrinknp_400_400/AAEAAQAAAAAAAATeAAAAJGNlYzVjOGYzLTNkMzMtNGEzZi1hNzAzLWE3OTgyMjExMmI1MQ.jpg) [Vyatcheslav Potravnyy](http://ua.linkedin.com/pub/vyatcheslav-potravnyy/4a/414/50b/)
   - ![Avatar](https://media.licdn.com/mpr/mpr/shrinknp_400_400/AAEAAQAAAAAAAAJzAAAAJDk4ZDBjNTBhLWRhNjQtNDU1OS1hOWQ2LTZhYTQ5NjMzY2JkYQ.jpg) [Dmitri Voronianski](http://ua.linkedin.com/in/voronianski/)
   - ![Avatar](http://m.c.lnkd.licdn.com/media/p/2/000/22a/288/3df5e98.jpg) [Dmitry Chaplinsky](http://ua.linkedin.com/pub/dmitry-chaplinsky/24/784/760)
   - ![Avatar](http://s24.postimg.org/m8b7ulrz9/photo.jpg) [Viktor Turskyi](https://www.linkedin.com/in/turskyi)

--- a/index.md
+++ b/index.md
@@ -5,7 +5,7 @@ layout: default
   - # ![KyivJS](/static/kyiv-js-rectangle-no-alpha.png)
   - [Twitter](https://twitter.com/kyivjs)
   - [Gitter](https://gitter.im/dev-ua/frontend-ua/kyivjs)
-  - [Регистрация](https://docs.google.com/forms/d/1STin1SD4o1lx9DNCUTqFrwjc5JxzOPROyDb8EJUz2CI/viewform)
+  - [Регистрация<br> скоро откроется]()
 
 ## Следующая встреча: TBA
 <!--
@@ -17,10 +17,23 @@ layout: default
 
 ### [30 января, 2016](http://dou.ua/calendar/9623/), [Видео](javascript:alert\('Скоро будут'\);)
 
-  - ![Аватар](https://media.licdn.com/mpr/mpr/shrinknp_400_400/p/7/005/0a8/057/07bb452.jpg) [Денис Зайченко](https://www.linkedin.com/in/dzaichenko)
-  - ![Аватар](https://media.licdn.com/mpr/mpr/shrinknp_400_400/AAEAAQAAAAAAAAZDAAAAJGM0ZTIzMzRkLTUzMjEtNDU3Yi1hNTM4LTI1YzZkNWIxZTNkZA.jpg) [Павел Пономаренко](https://github.com/theshock)
-  - ![Avatar](https://media.licdn.com/media/AAEAAQAAAAAAAAK6AAAAJDVlZTAwOTZlLTdkZDEtNDUzNy1hYjk5LTMzNTk5MjNkZDA0OQ.jpg) [Алексей Швайка](https://www.linkedin.com/in/ashvayka)
-  - ![Avatar](https://media.licdn.com/mpr/mpr/shrinknp_400_400/p/7/005/0ac/25b/06c95fa.jpg) [Евгений Сафронов](https://github.com/javacodegeek)
+  - ![Аватар](https://media.licdn.com/mpr/mpr/shrinknp_400_400/p/7/005/0a8/057/07bb452.jpg)
+    >
+      [**Денис Зайченко**](https://www.linkedin.com/in/dzaichenko)  
+      [Best practices - Angular JS]()
+  - ![Аватар](https://media.licdn.com/mpr/mpr/shrinknp_400_400/AAEAAQAAAAAAAAZDAAAAJGM0ZTIzMzRkLTUzMjEtNDU3Yi1hNTM4LTI1YzZkNWIxZTNkZA.jpg)
+    >
+      [**Павло Пономаренко**](https://github.com/theshock)  
+      [Плагіни для JavaScript ігор](http://slides.com/theshock/javascript-plugins/)
+  - ![Avatar](https://media.licdn.com/media/AAEAAQAAAAAAAAK6AAAAJDVlZTAwOTZlLTdkZDEtNDUzNy1hYjk5LTMzNTk5MjNkZDA0OQ.jpg)
+    >
+      [**Алексей Швайка**](https://www.linkedin.com/in/ashvayka)  
+      [ES6 Classes]()
+
+  - ![Avatar](https://media.licdn.com/mpr/mpr/shrinknp_400_400/p/7/005/0ac/25b/06c95fa.jpg)
+    >
+      [**Евгений Сафронов**](https://github.com/javacodegeek)
+      [Scala.JS](https://www.dropbox.com/s/dnkkgwjflul54ny/Scala-JS%20%28KyivJS%2030-01%29.pdf?dl=0)
 
 ### [5 декабря, 2015](http://dou.ua/calendar/9101/), [Видео](javascript:alert\('Скоро будут'\);)
 
@@ -51,7 +64,7 @@ layout: default
 
 ### [19 октября, 2013](http://dou.ua/calendar/3915/)
 
-  - ![Avatar](http://m.c.lnkd.licdn.com/media/p/6/000/23e/325/13e4d75.jpg) [Вячеслав Потравный](http://ua.linkedin.com/pub/vyatcheslav-potravnyy/4a/414/50b/)
+  - ![Avatar](https://media.licdn.com/mpr/mpr/shrinknp_400_400/AAEAAQAAAAAAAATeAAAAJGNlYzVjOGYzLTNkMzMtNGEzZi1hNzAzLWE3OTgyMjExMmI1MQ.jpg) [Вячеслав Потравный](http://ua.linkedin.com/pub/vyatcheslav-potravnyy/4a/414/50b/)
   - ![Avatar](https://media.licdn.com/mpr/mpr/shrinknp_400_400/AAEAAQAAAAAAAAJzAAAAJDk4ZDBjNTBhLWRhNjQtNDU1OS1hOWQ2LTZhYTQ5NjMzY2JkYQ.jpg) [Дмитрий Воронянский](http://ua.linkedin.com/in/voronianski/)
   - ![Avatar](http://m.c.lnkd.licdn.com/media/p/2/000/22a/288/3df5e98.jpg) [Дмитрий Чаплинский](http://ua.linkedin.com/pub/dmitry-chaplinsky/24/784/760)
   - ![Avatar](http://s24.postimg.org/m8b7ulrz9/photo.jpg) [Виктор Турский](https://www.linkedin.com/in/turskyi)

--- a/static/custom.css
+++ b/static/custom.css
@@ -105,6 +105,9 @@ h4 + ul > li > p + p > a {
   font-weight: normal;
 }
 
+.markdown-body > ul > li > blockquote {
+  border-left: none;
+}
 /* Responsive properties */
 
 .markdown-body > ul:first-child li {


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1506905/12720938/e41a92ea-c905-11e5-9445-360044c29e3d.png)
- Close registration (remove link to forms)
- add name of the talk into speaker block for last event
- link it to slides for last event
- update Potravny's photo
- change spelling for @theshock name
